### PR TITLE
要約用APIエンドポイントの変更

### DIFF
--- a/src/components/organisms/result/Summary.tsx
+++ b/src/components/organisms/result/Summary.tsx
@@ -42,7 +42,8 @@ export const Summary = memo(() => {
 
     useEffect(() => {
         (async() => {
-            const apiUrl = 'https://4p48gblcv2.execute-api.us-east-1.amazonaws.com/dev/summary/bedrock-async'
+            const apiUrl = 'https://4p48gblcv2.execute-api.us-east-1.amazonaws.com/dev/summary/bedrock-sqs'
+            // const apiUrl = 'https://4p48gblcv2.execute-api.us-east-1.amazonaws.com/dev/summary/bedrock-async'
             const requestOptions ={
                 method: 'POST',
                 headers:{'Content-Type': 'application/json'},


### PR DESCRIPTION
## What
要約に使用するAPIエンドポイントを変更した

## Why
今まではLambdaからLambdaを呼ぶアンチパターンだったので、Lambda,SQS,Lambdaの構成に変更